### PR TITLE
Cannot change default behavior when using respond_with.

### DIFF
--- a/lib/axlsx_rails/action_controller.rb
+++ b/lib/axlsx_rails/action_controller.rb
@@ -24,6 +24,10 @@ end
 # For respond_to default
 class ActionController::Responder
   def to_xlsx
-    controller.render :xlsx => controller.action_name
+    if @default_response
+      @default_response.call(options)
+    else
+      controller.render({:xlsx => controller.action_name}.merge(options))
+    end
   end
 end


### PR DESCRIPTION
Hello,

First, thank you for your awsome gem!
I'm using your gem, it really usefull.

But I found a problem when user users respond_with instead of respond_to.
http://api.rubyonrails.org/classes/ActionController/Responder.html

User uses responder style, all response block and options will be ignored.

For example, in controller

``` ruby
def index
   @products = Product.all
   respond_with(@products, any_options: :will_be_ignored) do |format|
      format.xlsx {
        # Actions before xlsx donwload, like;
        record_export_activity :xlsx
        #  However, this block will not be called.
      }
end 
```

I wrote a patch, description follows;

Fix responder method to keep comaptibility with default rails
responder style. These are needed if user uses responders.
- Accept render options
- Call user block when block is specified
