### PR TITLE
Do not publish spec files to rubygems

### DIFF
--- a/caxlsx_rails.gemspec
+++ b/caxlsx_rails.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.summary     = "A simple rails plugin to provide an xlsx renderer using the caxlsx gem."
   s.description = "Caxlsx_Rails provides an Caxlsx renderer so you can move all your spreadsheet code from your controller into view files. Partials are supported so you can organize any code into reusable chunks (e.g. cover sheets, common styling, etc.) You can use it with acts_as_caxlsx, placing the to_xlsx call in a view and adding ':package => xlsx_package' to the parameter list. Now you can keep your controllers thin!"
 
-  s.files = Dir["{app,config,db,lib}/**/*"] + Dir['[A-Z]*'] - ['Guardfile']
+  s.files = Dir["{app,config,db,lib}/**/*"] + Dir['[A-Z]*'] - Dir["spec/**/*"] - ['Guardfile']
   s.test_files = Dir["spec/**/*"] + ['Guardfile']
 
   s.add_dependency "actionpack", ">= 3.1"


### PR DESCRIPTION
Hello 👋

**What is this PR?**

Making sure that the spec/ folder is not published to rubygems.
As RubyGems points out, the test_files option is ignored

**Why?**

The specs are no use to the end user, and they inflate the project size. Heroku's slug size cap is 500 MB, the specs of this gem account for 14.7 MB. This change is important for us, as the limit of 500 MB has been reached.

Currently 👇

![image](https://user-images.githubusercontent.com/16024169/108219058-a1ff4a80-7135-11eb-8d8a-51b1585df91d.png)

After this PR:

![image](https://user-images.githubusercontent.com/16024169/108219115-b04d6680-7135-11eb-85f5-1a6293ef2a80.png)
