### PR TITLE
Add Ruby 3.1 and 3.2 to the CI matrix.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,8 @@ jobs:
           - "2.6"
           - "2.7"
           - "3.0"
+          - "3.1"
+          - "3.2"
 
         include:
           - rails: "4.2"
@@ -39,17 +41,47 @@ jobs:
           - rails: "4.2"
             ruby: "3.0"
 
+          - rails: "4.2"
+            ruby: "3.1"
+
+          - rails: "4.2"
+            ruby: "3.2"
+
           - rails: "5.0"
             ruby: "3.0"
+
+          - rails: "5.0"
+            ruby: "3.1"
+
+          - rails: "5.0"
+            ruby: "3.2"
 
           - rails: "5.1"
             ruby: "3.0"
 
+          - rails: "5.1"
+            ruby: "3.1"
+
+          - rails: "5.1"
+            ruby: "3.2"
+
           - rails: "5.2"
             ruby: "3.0"
 
+          - rails: "5.2"
+            ruby: "3.1"
+
+          - rails: "5.2"
+            ruby: "3.2"
+
           - rails: "6.0"
             ruby: "2.4"
+
+          - rails: "6.0"
+            ruby: "3.1"
+
+          - rails: "6.0"
+            ruby: "3.2"
 
           - rails: "6.1"
             ruby: "2.4"
@@ -67,7 +99,7 @@ jobs:
       BUNDLE_GEMFILE: ${{ github.workspace }}/spec/gemfiles/Gemfile.rails-${{ matrix.rails }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install ruby
         uses: ruby/setup-ruby@v1

--- a/spec/axlsx_request_spec.rb
+++ b/spec/axlsx_request_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 describe 'Caxlsx request', :type => :request do
 
   after(:each) do
-    if File.exists? '/tmp/caxlsx_temp.xlsx'
+    if File.exist? '/tmp/caxlsx_temp.xlsx'
       File.unlink '/tmp/caxlsx_temp.xlsx'
     end
   end


### PR DESCRIPTION
Also updates the checkout action versions to v3.
Replaced the use of a the deprecated `File#exists?` with `File#exist?` to get Ruby 3.2 green.

Runs green on my fork.