### PR TITLE
Add changelog_uri to gemspec

### DIFF
--- a/caxlsx_rails.gemspec
+++ b/caxlsx_rails.gemspec
@@ -13,6 +13,10 @@ Gem::Specification.new do |s|
   s.summary     = 'A simple rails plugin to provide an xlsx renderer using the caxlsx gem.'
   s.description = "Caxlsx_Rails provides an Caxlsx renderer so you can move all your spreadsheet code from your controller into view files. Partials are supported so you can organize any code into reusable chunks (e.g. cover sheets, common styling, etc.) You can use it with acts_as_caxlsx, placing the to_xlsx call in a view and adding ':package => xlsx_package' to the parameter list. Now you can keep your controllers thin!"
 
+  s.metadata = {
+    "changelog_uri" => "https://github.com/caxlsx/caxlsx_rails/blob/master/CHANGELOG.md"
+  }
+
   s.files = Dir['lib/**/*', 'CHANGELOG.md', 'README.md', 'MIT-LICENSE', 'caxlsx_rails.gemspec']
 
   s.add_dependency 'actionpack', '>= 3.1'


### PR DESCRIPTION
Supported here: https://guides.rubygems.org/specification-reference/#metadata
Useful for running https://github.com/MaximeD/gem_updater