### PR TITLE
Fix tested versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ See [previous installations](#previous-installations) if needed.
 
 ## Requirements
 
-* Tested on Rails 6.1, and 7.x.
-* Supported Ruby versions: 2.6, 2.7, 3.x
+* Tested on Rails 6.1, 7.x, and 8.x.
+* Supported Ruby versions: 2.6, 2.7, 3.x, and 4.0
 * Minimum Caxlsx version: 4.0
 
 ## FYI


### PR DESCRIPTION
According to the CI, caxlsx_rails is also tested against Rails 8.x and Ruby 4.