### PR TITLE
Fix MissingTemplate on Rails >= 8.0 with prepended controller modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 **Unreleased**
 
+- Fix `ActionView::MissingTemplate` on Rails >= 8.0 when a module is prepended to the controller: derive template lookup prefixes from the controller's `_prefixes` instead of `ancestors.take_while`
 
 **April 1, 2026**: 0.7.1 release
 

--- a/lib/axlsx_rails/action_controller.rb
+++ b/lib/axlsx_rails/action_controller.rb
@@ -22,9 +22,14 @@ ActionController::Renderers.add :xlsx do |filename, options|
   #
   if options[:template].nil?
     options[:template] ||= action_name
-    options[:prefixes] ||= self.class.ancestors
-                               .take_while { |a| a.respond_to?(:controller_path) }
-                               .map(&:controller_path)
+    # Use the controller's _prefixes (built from the superclass chain) instead of
+    # deriving prefixes from `ancestors`: a module prepended to the controller
+    # (memo_wise, instrumentation gems, ...) is the first ancestor and stops a
+    # take_while immediately, yielding no prefixes at all. Up to Rails 7.2 this
+    # branch was dead code because render option normalization ran before custom
+    # renderers and had already defaulted :template and :prefixes; Rails 8.0
+    # moved that normalization after the renderer, exposing the bug.
+    options[:prefixes] ||= _prefixes
   end
 
   options[:template] = filename.gsub(%r{^.*/}, '') if options[:template] == action_name

--- a/spec/rails_app/app/controllers/examples/prepended_module_controller.rb
+++ b/spec/rails_app/app/controllers/examples/prepended_module_controller.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Examples
+  class PrependedModuleController < ApplicationController
+    # Gems like memo_wise or instrumentation libraries prepend modules into
+    # controllers. A prepended module becomes the first entry in `ancestors`
+    # and does not respond to `controller_path`, so a prefix computation based
+    # on `ancestors.take_while { |a| a.respond_to?(:controller_path) }`
+    # returns an empty array for this controller.
+    module Prepended; end
+    prepend Prepended
+
+    def show
+      render xlsx: 'show'
+    end
+  end
+end

--- a/spec/rails_app/app/views/examples/prepended_module/show.xlsx.axlsx
+++ b/spec/rails_app/app/views/examples/prepended_module/show.xlsx.axlsx
@@ -1,0 +1,6 @@
+wb = xlsx_package.workbook
+
+wb.add_worksheet(name: 'Test') do |sheet|
+  sheet.add_row ['one', 'two', 'three']
+  sheet.add_row ['a', 'b', 'c']
+end

--- a/spec/rails_app/config/routes.rb
+++ b/spec/rails_app/config/routes.rb
@@ -7,5 +7,6 @@ Rails.application.routes.draw do
     resources :render_template, only: :show
     resource :respond_to, only: :show, controller: :respond_to
     resource :respond_with, only: :show, controller: :respond_with
+    resource :prepended_module, only: :show, controller: :prepended_module
   end
 end

--- a/spec/rails_app/spec/requests/prepended_module_controller_spec.rb
+++ b/spec/rails_app/spec/requests/prepended_module_controller_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# Regression test: on Rails >= 8.0, render option normalization runs AFTER
+# custom renderers (rails/rails moved it from _normalize_render into
+# render_to_body), so the renderer's own template/prefixes defaulting is
+# actually exercised. Computing prefixes from `ancestors.take_while` yields []
+# when a module is prepended to the controller, so the template was looked up
+# at the view-paths root and raised ActionView::MissingTemplate.
+describe Examples::PrependedModuleController do
+  it 'resolves the template although a module is prepended to the controller' do
+    visit '/examples/prepended_module.xlsx'
+
+    expect(page.response_headers['Content-Type']).to start_with 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+    validate_xlsx_file(page.source)
+  end
+end


### PR DESCRIPTION
# Fix `MissingTemplate` on Rails >= 8.0 when a module is prepended to the controller

## Symptom

On Rails 8.0+, `render xlsx: "show"` raises:

    ActionView::MissingTemplate (Missing template /show with {locale: [:en], formats: [:xlsx], ...})

— note the bare `/show`: the template is looked up at the view-paths root with **no prefixes**, instead of under the controller's view directory. This happens for any controller that has a module prepended to it (`memo_wise`, instrumentation/APM gems, etc.). On Rails <= 7.2 the same code works fine.

## Root cause

Two things combine:

1. **Rails 8.0 reordered render option normalization.** Through Rails 7.2, `_normalize_render` ran *before* custom renderers, so `options[:template]` was already defaulted to the action name and `options[:prefixes]` to the controller's `_prefixes` by the time this gem's `:xlsx` renderer block executed — the gem's own `if options[:template].nil?` defaulting was dead code. Rails 8.0 moved that normalization into `render_to_body` (`_normalize_options` became `_process_render_template_options` in `ActionView::Rendering`), which runs *after* the renderer. So on 8.0 the gem's defaulting branch is exercised for the first time.

2. **The gem's prefix computation breaks on prepended modules.**

   ```ruby
   options[:prefixes] ||= self.class.ancestors
                              .take_while { |a| a.respond_to?(:controller_path) }
                              .map(&:controller_path)
   ```

   A prepended module is the *first* entry in `ancestors` and does not respond to `controller_path`, so `take_while` stops immediately and returns `[]`. With empty prefixes, the bare template name is searched at the view-paths root → `MissingTemplate`.

## Fix

Use the controller's `_prefixes` instead. It is built from the superclass chain (`local_prefixes + superclass._prefixes`, see `AbstractController::ViewPaths`), so it is immune to prepended modules — and it is exactly the value Rails itself injected before 8.0 and still uses for a bare `render :action`, so behavior is identical for vanilla controllers.

## Test

Adds `Examples::PrependedModuleController` (prepends an empty module to mirror what memo_wise & co. do) with a request spec. Without the fix it fails on Rails 8.0/8.1 with the exact error above; it passes on <= 7.2 either way, since there the normalization-order made the branch dead code. Suite verified green locally on Rails 7.1, 7.2, 8.0 and 8.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
